### PR TITLE
Make errors visible through c99wrap

### DIFF
--- a/compilewrap.c
+++ b/compilewrap.c
@@ -90,6 +90,7 @@ static int exec_argv_out(char **argv, const char *out)
         si.cb = sizeof(si);
         si.dwFlags = STARTF_USESTDHANDLES;
         si.hStdOutput = pipe_write;
+        si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
         inherit = TRUE;
     }
     if (CreateProcess(NULL, cmdline, NULL, NULL, inherit, 0, NULL, NULL, &si, &pi)) {

--- a/compilewrap.c
+++ b/compilewrap.c
@@ -313,6 +313,11 @@ int main(int argc, char *argv[])
             cc_argv[cc_argc++]     = temp_file_2;
         } else if (!strcmp(argv[i], "-MMD") || !strncmp(argv[i], "-D", 2)) {
             // Preprocessor-only parameter
+            if (!strcmp(argv[i], "-D"))
+            {   // Handle -D DEFINE style
+                pass_argv[pass_argc++] = argv[i];
+                cpp_argv[cpp_argc++]   = argv[i++];
+            }
             pass_argv[pass_argc++] = argv[i];
             cpp_argv[cpp_argc++]   = argv[i++];
         } else if (!strcmp(argv[i], "-MF") || !strcmp(argv[i], "-MT")) {

--- a/compilewrap.c
+++ b/compilewrap.c
@@ -313,8 +313,8 @@ int main(int argc, char *argv[])
             cc_argv[cc_argc++]     = temp_file_2;
         } else if (!strcmp(argv[i], "-MMD") || !strncmp(argv[i], "-D", 2)) {
             // Preprocessor-only parameter
-            if (!strcmp(argv[i], "-D"))
-            {   // Handle -D DEFINE style
+            if (!strcmp(argv[i], "-D")) {
+                // Handle -D DEFINE style
                 pass_argv[pass_argc++] = argv[i];
                 cpp_argv[cpp_argc++]   = argv[i++];
             }


### PR DESCRIPTION
Currently if errors happens during preprocessing or compile step, they
are completely invisible with c99wrap in msys make. It is necessary to
connect stderr pipe to make them visible.
